### PR TITLE
Upstream fixes and work on support for infoboxes

### DIFF
--- a/modules/aos_common.less
+++ b/modules/aos_common.less
@@ -164,6 +164,7 @@ header.mw-header li:not(.new),
 /* Color of visited links for content and left column
  * (not for MediaWiki navigation elements above the page) */
 #content,
+#mw-panel-toc,
 // Legacy Vector
 #mw-panel li:not(.new),
 // MonoBook

--- a/modules/aos_common.less
+++ b/modules/aos_common.less
@@ -142,21 +142,22 @@ header.mw-header li:not(.new),
 // MonoBook
 #column-one li:not(.new),
 #footer {
-    a:not(.new):not([role=button]) {
+    a:not([role=button]) {
+      &:not(.new) {
         text-decoration: none;
         color: @link-color-normal !important;
-    }
-
-    a:not(.new):not([role=button]):hover {
-        text-decoration: underline;
-        background-color: transparent;
-        color: @link-color-hover !important;
-    }
-
-    a:active:not([role=button]), a:not([role=button]):focus,
-    /* a:hover overrides a:active, which we don't want' */
-    a:not([role=button]):active:hover, a:not([role=button]):focus:hover {
+        &:hover {
+          text-decoration: underline;
+          background-color: transparent;
+          color: @link-color-hover !important;
+        }
+      }
+  
+      &:active, &:focus,
+      /* a:hover overrides a:active, which we don't want' */
+      &:active:hover, &:focus:hover {
         color: @link-color-active !important;
+      }
     }
 }
 

--- a/modules/aos_common.less
+++ b/modules/aos_common.less
@@ -19,6 +19,12 @@
     }
 }
 
+@media (max-width: @screen-sm-min) {
+    .infobox {
+        width: 100% !important;
+    }
+}
+
 .mw-first-heading {
     margin: -2.5vw 0 0 0;
 }

--- a/modules/aos_common.less
+++ b/modules/aos_common.less
@@ -142,22 +142,20 @@ header.mw-header li:not(.new),
 // MonoBook
 #column-one li:not(.new),
 #footer {
-    a:not(.new) {
+    a:not(.new):not([role=button]) {
         text-decoration: none;
         color: @link-color-normal !important;
     }
 
-    a:not(.new):hover {
+    a:not(.new):not([role=button]):hover {
         text-decoration: underline;
         background-color: transparent;
         color: @link-color-hover !important;
     }
 
-    a:active,
-    a:focus,
+    a:active:not([role=button]), a:not([role=button]):focus,
     /* a:hover overrides a:active, which we don't want' */
-    a:active:hover,
-    a:focus:hover {
+    a:not([role=button]):active:hover, a:not([role=button]):focus:hover {
         color: @link-color-active !important;
     }
 }
@@ -173,7 +171,7 @@ header.mw-header li:not(.new),
 #p-tb li:not(.new)
 
     {
-    a:not(.new):visited {
+    a:not(.new):not([role=button]):visited {
         color: @link-color-visited !important;
     }
 }

--- a/modules/skins/vector.less
+++ b/modules/skins/vector.less
@@ -108,6 +108,33 @@ body.skin-vector-2022 {
     left: auto;
   }
 
+  // Fix style and layout of main menu in the left sidebar
+  @media screen {
+    // NOTE: #vector-main-menu alone is not unique as of MW 1.40
+    #vector-main-menu.vector-main-menu {
+      background: @content-background-color;
+      border: @content-border-style;
+      width: auto;
+      margin-left: 0;
+      margin-top: 0;
+      margin-bottom: 1em;
+    }
+  }
+  // Fix layout of the TOC menu in the left sidebar
+  @media screen and (min-width: 1000px) {
+    // NOTE: #mw-panel-toc alone is not specific enough
+    #mw-panel-toc.mw-table-of-contents-container {
+      margin-left: 0;
+      #vector-toc-pinned-container {
+        margin-top: 0 !important;
+        border: @content-border-style;
+        .vector-toc, .vector-toc::after {
+          width: auto;
+        }
+      }
+    }
+  }
+
   // Restore language links which disappeared in the Vector 2022 version 1.39
   #p-lang-btn.mw-portlet-empty {
     display: block;


### PR DESCRIPTION
Imports some upstream fixes from https://github.com/archlinux/archwiki/tree/master/extensions/ArchLinux and adds custom css to use the full width on small screens/mobile for infoboxes (currently wip).

Preview of the current state on infoboxes:

![image](https://github.com/user-attachments/assets/85d5dc79-8f77-46da-8f57-3d8e32152209)


Basically involves importing the right files from the PostmarketOS wiki and adjusting the used MediaWiki extensions.